### PR TITLE
fix lua bind bug

### DIFF
--- a/include/lua_bind.h
+++ b/include/lua_bind.h
@@ -91,7 +91,13 @@ static inline any lua_getanyvalue(lua_State*L, int i)
 			return (lua_Number)num;
 		}
 		else {
-			return (lua_Integer)inum;
+			lua_Integer n = (lua_Integer)num;
+			if (n > INT32_MAX) {
+				return (lua_Integer)n;
+			}
+			else {
+				return (int32_t)n;
+			}
 		}
 			
 	}


### PR DESCRIPTION
因为lua_Integer 被定义成double，所以lua 绑定c++函数的模板扩展的时候，int 类型的模板参数会被扩展成double类型，导致lua调用c++函数出现异常